### PR TITLE
remove duplicate include

### DIFF
--- a/exploit.c
+++ b/exploit.c
@@ -9,7 +9,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdlib.h>
 #include <assert.h>
 #include <unistd.h>
 #include <sys/wait.h>


### PR DESCRIPTION
stdlib.h was included twice; removed second instruction